### PR TITLE
Support USE_EXACT_EDGE_DRIVER_VERSION option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ EDGEDRIVER_VERSION=80.0.361.103
 
 If both browser binary path and version are provided, the package will skip binary fetch step and start with the driver download.
 
+By default, the version of the actually downloaded driver is the latest minor version for EDGEDRIVER_VERSION. To download exactly the same version as EDGEDRIVER_VERSION, use the npm config property `npm_config_use_exact_edgedriver_version`
+
+```shell
+npm install ms-chromium-edge-driver --npm_config_use_exact_edgedriver_version=1
+```
+
+Another option is to use the PATH variable `USE_EXACT_EDGE_DRIVER_VERSION`
+
+```shell
+USE_EXACT_EDGE_DRIVER_VERSION=1
+```
+
 ## Custom driver binary
 
 To get the msedgedriver from the filesystem instead of a web request use the npm config property `npm_config_edgedriver_path`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,10 +64,12 @@ const getBrowser = async (edgeBinaryPath: string | undefined, edgeDriverVersion:
 };
 
 const downloadDriver = async (version: string) => {
-  const versionMatcher = version === 'LATEST' ? 'LATEST_STABLE' : `LATEST_RELEASE_${version.split('.')[0]}`;
-  const response = await got.get(`${cdnUrl}/${versionMatcher}`);
-
-  version = response.body.replace(/[^\d.]/g, '');
+  const useExactEdgeDriverVersion = process.env.npm_config_use_exact_edgedriver_version || process.env.USE_EXACT_EDGE_DRIVER_VERSION;
+  if (!useExactEdgeDriverVersion) {
+    const versionMatcher = version === 'LATEST' ? 'LATEST_STABLE' : `LATEST_RELEASE_${version.split('.')[0]}`;
+    const response = await got.get(`${cdnUrl}/${versionMatcher}`);
+    version = response.body.replace(/[^\d.]/g, '');
+  }
   process.stdout.write(`Downloading MS Edge Driver ${version}...\n`);
 
   const downloadUrl = `${cdnUrl}/${version}/edgedriver_${getOS()}.zip`;


### PR DESCRIPTION
It seems that if I specify EDGEDRIVER_VERSION=85.0.564.51 actually the latest edgeDriver for 85 (i.e. 85.0.564.60) is downaloded. 

This behavior is usually no problem. But since now 85.0.564.60 is strangely provided only for Mac on https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/, ms-edge-driver on Windows with EDGEDRIVER_VERSION=85.0.564.51 tries to download 85.0.564.60 and it fails. So, I cannot install EdgeDriver 85 with ms-edge-driver now.
With USE_EXACT_EDGE_DRIVER_VERSION, I can avoid such situation.
