### PR TITLE
Add npm config to cdn url resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { pipeline } from 'stream';
 import * as extract from 'extract-zip';
 import { getBrowserData } from './browser';
 import { getOS, isSupportedPlatform, isWin } from './os';
-const cdnUrl = process.env.EDGEDRIVER_CDNURL || 'https://msedgedriver.azureedge.net';
+const cdnUrl = process.env.npm_config_edgedriver_cdnurl || process.env.EDGEDRIVER_CDNURL || 'https://msedgedriver.azureedge.net';
 const mainDir = resolve(__dirname, '..');
 const outFile = 'msedgedriver.zip';
 const driverFolder = 'bin';


### PR DESCRIPTION
Provide support for configuring cdn url in npm config.  Match behavior of other similar configuration by processing npm config first followed by path.